### PR TITLE
Correct duration filter for durations of 10 seconds and longer

### DIFF
--- a/same-build-result.sh
+++ b/same-build-result.sh
@@ -125,8 +125,8 @@ if test -n "$OTHERDIR"; then
     sed -i -e "/W: filename-too-long-for-joliet/s,\(^.*-kmp-.*-kmp-\).*$,\1," $file1
     sed -i -e "/W: filename-too-long-for-joliet/s,\(^.*-kmp-.*-kmp-\).*$,\1," $file2
     # Remove durations from progress reports
-    sed -i -e "/I: \(filelist-initialization\|check-completed\) /s| [0-9]\+\.[0-9] s| x.x s|" $file1
-    sed -i -e "/I: \(filelist-initialization\|check-completed\) /s| [0-9]\+\.[0-9] s| x.x s|" $file2
+    sed -i -e "/I: \(filelist-initialization\|check-completed\) /s|[ 0-9]\+\.[0-9] s| x.x s|" $file1
+    sed -i -e "/I: \(filelist-initialization\|check-completed\) /s|[ 0-9]\+\.[0-9] s| x.x s|" $file2
     if ! cmp -s $file1 $file2; then
       echo "rpmlint.log files differ:"
       diff -u $file1 $file2 |head -n 20


### PR DESCRIPTION
The duration is a fixed width field, so both "__9.1 s" and "_10.5 s" should be replaced by " x.x s"
